### PR TITLE
Fixed string parsing bug & added a test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,10 @@ lazy_static = "1.4"
 quote = "1.0"
 regex = "1"
 
+[dependencies.syn]
+version = "1.0"
+default-features = false
+features = ["derive", "full", "parsing", "proc-macro"]
+
 [dev-dependencies]
 doc-comment = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,16 +4,15 @@ extern crate doc_comment;
 
 #[macro_use]
 extern crate lazy_static;
-
 extern crate proc_macro;
-
 #[macro_use]
 extern crate quote;
-
 extern crate regex;
+extern crate syn;
 
-use proc_macro::{TokenStream, TokenTree::*};
+use proc_macro::TokenStream;
 use regex::Regex;
+use syn::{parse_macro_input, LitStr};
 
 /// Adds ANSI escape codes to a formatting string, allowing ANSI colors to be set at compile time instead of runtime.
 ///
@@ -27,25 +26,8 @@ use regex::Regex;
 /// ```
 #[proc_macro]
 pub fn ansi(tokens: TokenStream) -> TokenStream {
-    let mut tokens = tokens.into_iter();
-    let format_str = match tokens.next() {
-        None => return TokenStream::from(quote! { format!() }),
-        Some(Literal(literal)) => literal,
-        _ => {
-            return TokenStream::from(quote! { compile_error!("First argument must be a literal") })
-        }
-    };
-
-    let format_str = format_str.to_string();
-    let mut format_str = format_str.chars();
-    let format_str: String = match (format_str.next(), format_str.next_back()) {
-        (Some('"'), Some('"')) => format_str.collect(),
-        _ => {
-            return TokenStream::from(
-                quote! { compile_error!("First argument must be a literal string") },
-            )
-        }
-    };
+    let format_str = parse_macro_input!(tokens as LitStr);
+    let format_str = format_str.value();
 
     lazy_static! {
         static ref ANSI_ARG: Regex =
@@ -117,17 +99,12 @@ pub fn ansi(tokens: TokenStream) -> TokenStream {
         };
         format_arg
     });
-    let format_str = format_str.to_string();
-    let format_str = format_str.as_str();
 
-    let format_str = quote! {
+    let tokens = quote! {
         #format_str
     };
 
-    let format_str = TokenStream::from(format_str);
-
-    let tokens = format_str;
-    tokens
+    TokenStream::from(tokens)
 }
 
 #[cfg(doctest)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,7 @@ use syn::{parse_macro_input, LitStr};
 /// ```
 #[proc_macro]
 pub fn ansi(tokens: TokenStream) -> TokenStream {
-    let format_str = parse_macro_input!(tokens as LitStr);
-    let format_str = format_str.value();
+    let format_str = parse_macro_input!(tokens as LitStr).value();
 
     lazy_static! {
         static ref ANSI_ARG: Regex =

--- a/tests/escapes.rs
+++ b/tests/escapes.rs
@@ -1,0 +1,9 @@
+#[macro_use]
+extern crate ansiform;
+
+#[test]
+fn escapes_work() {
+    assert_eq!(ansi!("\n"), "\n");
+    assert_eq!(ansi!("\r"), "\r");
+    assert_eq!(ansi!("{}\n"), "{}\n");
+}


### PR DESCRIPTION
`ansi!()` now uses `syn` to parse the format string.
This ensures that the output string handles character escapes correctly.

Fixes #4 